### PR TITLE
Update Spring AI documentation to reflect API changes

### DIFF
--- a/content/blog/2024/2024-03-10-getting-started-with-spring-ai-and-open-ai.md
+++ b/content/blog/2024/2024-03-10-getting-started-with-spring-ai-and-open-ai.md
@@ -96,7 +96,7 @@ We can configure the **ChatClient** to use OpenAI by providing the API key and o
 
 ```properties
 spring.ai.openai.api-key=${OPENAI_API_KEY}
-spring.ai.openai.chat.model=gpt-3.5-turbo
+spring.ai.openai.chat.model=gpt-4o-mini
 spring.ai.openai.chat.temperature=0.7
 ```
 
@@ -185,7 +185,7 @@ By using **SystemMessage**, we can define the role and provide additional contex
 In the previous examples, we get the response from LLMs as Strings.
 We can use **OutputConverters** to parse the response and extract the required information in the desired format.
 
-As of now, Spring AI provides the following type of **OutputConverters**:
+Spring AI provides the following type of **OutputConverters**:
 * **BeanOutputConverter** - To parse the response and convert into a Java Bean.
 * **MapOutputConverter** - To parse the response and convert into a Map.
 * **ListOutputConverter** - To parse the response and convert into a List.

--- a/content/blog/2024/2024-03-15-spring-ai-rag-using-embedding-models-vector-databases.md
+++ b/content/blog/2024/2024-03-15-spring-ai-rag-using-embedding-models-vector-databases.md
@@ -89,8 +89,8 @@ For example, if you want to use OpenAI's EmbeddingModel, you can add the followi
 ```xml
 <dependency>
     <groupId>org.springframework.ai</groupId>
-    <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
-    <version>1.0.0-M1</version>
+    <artifactId>spring-ai-starter-model-openai</artifactId>
+    <version>2.0.0-M4</version>
 </dependency>
 ```
 
@@ -126,7 +126,7 @@ class MyComponent {
         EmbeddingRequest embeddingRequest =
                 new EmbeddingRequest(List.of("I like Spring Boot"),
                         OpenAiEmbeddingOptions.builder()
-                                .withModel("text-davinci-003")
+                                .model("text-embedding-3-small")
                                 .build());
         EmbeddingResponse embeddingResponse = embeddingModel.call(embeddingRequest);
         List<Double> embeddings3 = embeddingResponse.getResult().getOutput();
@@ -150,7 +150,7 @@ Let us see how to use **SimpleVectorStore** to store and retrieve embeddings.
 class AppConfig {
     @Bean
     VectorStore vectorStore(EmbeddingModel embeddingModel) {
-        return new SimpleVectorStore(embeddingModel);
+        return SimpleVectorStore.builder(embeddingModel).build();
     }
 }
 
@@ -170,17 +170,17 @@ class MyComponent {
         vectorStore.add(documents);
         
         // Retrieve embeddings
-        SearchRequest query = SearchRequest.query("Spring Boot").withTopK(2);
+        SearchRequest query = SearchRequest.builder().query("Spring Boot").topK(2).build();
         List<Document> similarDocuments = vectorStore.similaritySearch(query);
         String relevantData = similarDocuments.stream()
-                            .map(Document::getContent)
+                            .map(Document::getText)
                             .collect(Collectors.joining(System.lineSeparator()));
     }
 }
 ```
 
 In the above code, we are adding the Documents to the VectorStore,
-which internally converts the documents into embeddings using the EmbeddingClient
+which internally converts the documents into embeddings using the EmbeddingModel
 and stores them in the Vector Database.
 
 We are then querying the VectorStore using natural language and retrieving relevant data.
@@ -246,9 +246,9 @@ class RAGController {
     Person chatWithRag(@RequestParam String name) {
         // Querying the VectorStore using natural language looking for the information about a person.
         List<Document> similarDocuments = 
-                vectorStore.similaritySearch(SearchRequest.query(name).withTopK(2));
+                vectorStore.similaritySearch(SearchRequest.builder().query(name).topK(2).build());
         String information = similarDocuments.stream()
-                .map(Document::getContent)
+                .map(Document::getText)
                 .collect(Collectors.joining(System.lineSeparator()));
         
         // Constructing the systemMessage to indicate the AI model to use the passed information


### PR DESCRIPTION
## Summary
This PR updates the Spring AI blog documentation to reflect recent API changes and improvements in the Spring AI framework, including dependency updates, method signature changes, and API modernizations.

## Key Changes

### Dependency Updates
- Updated OpenAI starter artifact from `spring-ai-openai-spring-boot-starter` to `spring-ai-starter-model-openai`
- Updated version from `1.0.0-M1` to `2.0.0-M4`

### API Method Updates
- Changed `EmbeddingOptions.withModel()` to `model()` builder method
- Updated embedding model from `text-davinci-003` to `text-embedding-3-small`
- Changed `SimpleVectorStore` instantiation from constructor to builder pattern: `SimpleVectorStore.builder(embeddingModel).build()`
- Updated `SearchRequest` from fluent API (`SearchRequest.query().withTopK()`) to builder pattern: `SearchRequest.builder().query().topK().build()`
- Changed `Document.getContent()` to `Document.getText()` throughout examples

### Documentation Improvements
- Updated default OpenAI chat model from `gpt-3.5-turbo` to `gpt-4o-mini`
- Corrected terminology from `EmbeddingClient` to `EmbeddingModel` for consistency
- Minor text refinement: "As of now" → removed for better readability

## Notable Implementation Details
The changes reflect a shift towards builder patterns for object construction (SimpleVectorStore, SearchRequest) and more consistent naming conventions across the API (getText vs getContent). These updates ensure the documentation accurately reflects the current Spring AI 2.0.0-M4 API surface.

https://claude.ai/code/session_019ob47aF1WaKXYj52CsNkh8